### PR TITLE
add separate pojo for creating and reading employees

### DIFF
--- a/src/main/java/com/example/steepjakarta/api/EmployeeResource.java
+++ b/src/main/java/com/example/steepjakarta/api/EmployeeResource.java
@@ -1,5 +1,6 @@
 package com.example.steepjakarta.api;
 
+import com.example.steepjakarta.domain.datatransfer.CreateEmployeeDTO;
 import com.example.steepjakarta.domain.datatransfer.EmployeeDTO;
 import com.example.steepjakarta.domain.service.EmployeeService;
 import jakarta.inject.Inject;
@@ -32,7 +33,7 @@ public class EmployeeResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response createEmployee(EmployeeDTO employeeDTO) {
+    public Response createEmployee(CreateEmployeeDTO employeeDTO) {
         employeeService.create(employeeDTO);
         return Response.ok(employeeDTO).build();
     }
@@ -41,7 +42,7 @@ public class EmployeeResource {
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response updateEmployee(@PathParam("id") Long id, EmployeeDTO employeeDTO) {
+    public Response updateEmployee(@PathParam("id") Long id, CreateEmployeeDTO employeeDTO) {
         employeeService.update(id, employeeDTO);
         return Response.ok(employeeDTO).build();
     }

--- a/src/main/java/com/example/steepjakarta/domain/Util.java
+++ b/src/main/java/com/example/steepjakarta/domain/Util.java
@@ -1,5 +1,6 @@
 package com.example.steepjakarta.domain;
 
+import com.example.steepjakarta.domain.datatransfer.CreateEmployeeDTO;
 import com.example.steepjakarta.domain.datatransfer.EmployeeDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.commons.lang3.Validate;
@@ -14,7 +15,7 @@ public class Util {
         return UUID.randomUUID().toString().replace("-", "");
     }
 
-    public static void validateEmployee(EmployeeDTO employee) {
+    public static void validateEmployee(CreateEmployeeDTO employee) {
         Validate.notNull(employee, "Employee cannot be null");
         Validate.notEmpty(employee.getFirstName(), "First name cannot be empty");
         Validate.notEmpty(employee.getLastName(), "Last name cannot be empty");

--- a/src/main/java/com/example/steepjakarta/domain/datatransfer/CreateEmployeeDTO.java
+++ b/src/main/java/com/example/steepjakarta/domain/datatransfer/CreateEmployeeDTO.java
@@ -9,11 +9,10 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class EmployeeDTO {
-//    private Long id; commenting this out as this can potentially be used by malicious actors to brute force our system
+public class CreateEmployeeDTO {
     private String firstName;
     private String lastName;
     private String email;
+    private String password;
     private LocalDate birthday;
-    private String displayID;
 }

--- a/src/main/java/com/example/steepjakarta/domain/service/BasicCRUDService.java
+++ b/src/main/java/com/example/steepjakarta/domain/service/BasicCRUDService.java
@@ -1,6 +1,6 @@
 package com.example.steepjakarta.domain.service;
 
-public interface BasicCRUDService<T> {
+public interface BasicCRUDService<T, R> {
 
     default void delete(Long id) {}
 
@@ -8,9 +8,9 @@ public interface BasicCRUDService<T> {
         return null;
     }
 
-    default void update(Long id,T obj) {}
+    default void update(Long id, T obj) {}
 
-    default T get(Long id) { return null; }
+    default R get(Long id) { return null; }
 
-    default Iterable<T> getAll() { return null; }
+    default Iterable<R> getAll() { return null; }
 }

--- a/src/main/java/com/example/steepjakarta/domain/service/EmployeeService.java
+++ b/src/main/java/com/example/steepjakarta/domain/service/EmployeeService.java
@@ -2,6 +2,7 @@ package com.example.steepjakarta.domain.service;
 
 import com.example.steepjakarta.domain.Util;
 import com.example.steepjakarta.domain.dataaccess.EmployeeRepository;
+import com.example.steepjakarta.domain.datatransfer.CreateEmployeeDTO;
 import com.example.steepjakarta.domain.datatransfer.EmployeeDTO;
 import com.example.steepjakarta.domain.models.Employee;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class EmployeeService implements BasicCRUDService<EmployeeDTO> {
+public class EmployeeService implements BasicCRUDService<CreateEmployeeDTO, EmployeeDTO> {
 
     @Inject
     EmployeeRepository employeeRepository;
@@ -27,7 +28,7 @@ public class EmployeeService implements BasicCRUDService<EmployeeDTO> {
     }
 
     @Override
-    public String create(EmployeeDTO employeeDto) {
+    public String create(CreateEmployeeDTO employeeDto) {
         Util.validateEmployee(employeeDto);
 
         Employee employee = mapToEmployee(employeeDto);
@@ -36,7 +37,7 @@ public class EmployeeService implements BasicCRUDService<EmployeeDTO> {
 
 
     @Override
-    public void update(Long id, EmployeeDTO employeeDTO) {
+    public void update(Long id, CreateEmployeeDTO employeeDTO) {
         Util.validateEmployee(employeeDTO);
 
         Employee employee = employeeRepository.findById(id);
@@ -65,7 +66,7 @@ public class EmployeeService implements BasicCRUDService<EmployeeDTO> {
     }
 
 
-    private Employee mapToEmployee(EmployeeDTO employeeDto) {
+    private Employee mapToEmployee(CreateEmployeeDTO employeeDto) {
         return Employee.builder()
                 .firstName(employeeDto.getFirstName())
                 .lastName(employeeDto.getLastName())

--- a/src/test/java/com/example/steepjakarta/api/EmployeeResourceTest.java
+++ b/src/test/java/com/example/steepjakarta/api/EmployeeResourceTest.java
@@ -1,5 +1,6 @@
 package com.example.steepjakarta.api;
 
+import com.example.steepjakarta.domain.datatransfer.CreateEmployeeDTO;
 import com.example.steepjakarta.domain.datatransfer.EmployeeDTO;
 import com.example.steepjakarta.domain.service.EmployeeService;
 import jakarta.ws.rs.core.Response;
@@ -26,15 +27,22 @@ public class EmployeeResourceTest {
     @InjectMocks
     private EmployeeResource employeeResource;
 
+    private CreateEmployeeDTO createEmployeeDTO;
     private EmployeeDTO employeeDTO;
 
     @BeforeEach
     void setUp() {
+        createEmployeeDTO = new CreateEmployeeDTO();
+        createEmployeeDTO.setFirstName("John");
+        createEmployeeDTO.setLastName("Doe");
+        createEmployeeDTO.setEmail("john.doe@example.com");
+        createEmployeeDTO.setPassword("password123");
+        createEmployeeDTO.setBirthday(LocalDate.now());
+
         employeeDTO = new EmployeeDTO();
         employeeDTO.setFirstName("John");
         employeeDTO.setLastName("Doe");
         employeeDTO.setEmail("john.doe@example.com");
-        employeeDTO.setPassword("password123");
         employeeDTO.setBirthday(LocalDate.now());
     }
 
@@ -63,23 +71,23 @@ public class EmployeeResourceTest {
     @Test
     void testCreateEmployee() {
         String expectedId = "123e4567e89b12d3a456426614174000";
-        when(employeeService.create(any(EmployeeDTO.class))).thenReturn(expectedId);
+        when(employeeService.create(any(CreateEmployeeDTO.class))).thenReturn(expectedId);
 
 
-        Response response = employeeResource.createEmployee(employeeDTO);
+        Response response = employeeResource.createEmployee(createEmployeeDTO);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        verify(employeeService, times(1)).create(any(EmployeeDTO.class));
+        verify(employeeService, times(1)).create(any(CreateEmployeeDTO.class));
     }
 
     @Test
     void testUpdateEmployee() {
-        doNothing().when(employeeService).update(eq(1L), any(EmployeeDTO.class));
+        doNothing().when(employeeService).update(eq(1L), any(CreateEmployeeDTO.class));
 
-        Response response = employeeResource.updateEmployee(1L, employeeDTO);
+        Response response = employeeResource.updateEmployee(1L, createEmployeeDTO);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        verify(employeeService, times(1)).update(eq(1L), any(EmployeeDTO.class));
+        verify(employeeService, times(1)).update(eq(1L), any(CreateEmployeeDTO.class));
     }
 
     @Test

--- a/src/test/java/com/example/steepjakarta/domain/UtilTest.java
+++ b/src/test/java/com/example/steepjakarta/domain/UtilTest.java
@@ -1,4 +1,5 @@
 package com.example.steepjakarta.domain;
+import com.example.steepjakarta.domain.datatransfer.CreateEmployeeDTO;
 import com.example.steepjakarta.domain.datatransfer.EmployeeDTO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +22,7 @@ public class UtilTest {
 
     @Test
     void testValidateEmployee() {
-        EmployeeDTO employeeDTO = new EmployeeDTO();
+        CreateEmployeeDTO employeeDTO = new CreateEmployeeDTO();
         employeeDTO.setFirstName("John");
         employeeDTO.setLastName("Doe");
         employeeDTO.setEmail("john.doe@example.com");
@@ -33,7 +34,7 @@ public class UtilTest {
 
     @Test
     void testValidateEmployeeInvalidEmail() {
-        EmployeeDTO employeeDTO = new EmployeeDTO();
+        CreateEmployeeDTO employeeDTO = new CreateEmployeeDTO();
         employeeDTO.setFirstName("John");
         employeeDTO.setLastName("Doe");
         employeeDTO.setEmail("invalid-email");

--- a/src/test/java/com/example/steepjakarta/domain/service/EmployeeServiceTest.java
+++ b/src/test/java/com/example/steepjakarta/domain/service/EmployeeServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.steepjakarta.domain.service;
 
 import com.example.steepjakarta.domain.dataaccess.EmployeeRepository;
+import com.example.steepjakarta.domain.datatransfer.CreateEmployeeDTO;
 import com.example.steepjakarta.domain.datatransfer.EmployeeDTO;
 import com.example.steepjakarta.domain.models.Employee;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,12 +28,12 @@ class EmployeeServiceTest {
     @Mock
     private EmployeeRepository employeeRepository;
 
-    private EmployeeDTO employeeDTO;
+    private CreateEmployeeDTO employeeDTO;
     private Employee employee;
 
     @BeforeEach
     void setUp() {
-        employeeDTO = new EmployeeDTO();
+        employeeDTO = new CreateEmployeeDTO();
         employeeDTO.setFirstName("John");
         employeeDTO.setLastName("Doe");
         employeeDTO.setEmail("john.doe@example.com");


### PR DESCRIPTION
On creation, "displayID" is overwritten by the generated UUID
Let's have another POJO that is used solely for creating new objects